### PR TITLE
Update CachedSound.cs

### DIFF
--- a/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
+++ b/NAudioWpfDemo/FireAndForgetPlayback/CachedSound.cs
@@ -24,5 +24,22 @@ namespace NAudioWpfDemo.FireAndForgetPlayback
                 AudioData = wholeFile.ToArray();
             }
         }
+        public CachedSound(Stream sound) 
+        {
+            using (var audioFileReader = new WaveFileReader(sound))
+            {
+                WaveFormat = audioFileReader.WaveFormat;
+                var sp = audioFileReader.ToSampleProvider();
+                var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
+                var sourceSamples = (int)(audioFileReader.Length / (audioFileReader.WaveFormat.BitsPerSample / 8));
+                var sampleData = new float[sourceSamples];
+                int samplesread;
+                while ((samplesread = sp.Read(sampleData, 0, sourceSamples)) > 0)
+                {
+                    wholeFile.AddRange(sampleData.Take(samplesread));
+                }
+                AudioData = wholeFile.ToArray();                
+            }
+        }
     }
 }


### PR DESCRIPTION
Added new CachedSound constructor to play resource streams.
I played the wav file of Properties.Resource using the following source code:

public CachedSound(Stream sound)
{
    using (var audioFileReader = new WaveFileReader(sound))
    {
        WaveFormat = audioFileReader.WaveFormat;
        var sp = audioFileReader.ToSampleProvider();
        var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
        var sourceSamples = (int)(audioFileReader.Length / (audioFileReader.WaveFormat.BitsPerSample / 8));
        var sampleData = new float[sourceSamples];
        int samplesread;
        while ((samplesread = sp.Read(sampleData, 0, sourceSamples)) > 0)
        {
            wholeFile.AddRange(sampleData.Take(samplesread));
        }
        AudioData = wholeFile.ToArray();
    }
}